### PR TITLE
add delay due to interface reboots

### DIFF
--- a/fingerprintd/FingerprintDaemonProxy.cpp
+++ b/fingerprintd/FingerprintDaemonProxy.cpp
@@ -17,6 +17,7 @@
 #define LOG_NDEBUG 0
 #define LOG_TAG "FingerprintDaemonProxy"
 
+#include <unistd.h>
 #include <cutils/properties.h>
 #include <binder/IServiceManager.h>
 #include <hardware/hardware.h>
@@ -195,7 +196,9 @@ int32_t FingerprintDaemonProxy::cancel() {
 }
 
 uint64_t FingerprintDaemonProxy::getAuthenticatorId() {
-    ALOG(LOG_VERBOSE, LOG_TAG, "getAuthenticatorId()\n");
+    ALOG(LOG_VERBOSE, LOG_TAG, "================= getAuthenticatorId() before sleep ===============\n");
+    usleep(200000);
+    ALOG(LOG_VERBOSE, LOG_TAG, "================= getAuthenticatorId() after sleep  ===============\n");
     return mDevice->get_authenticator_id(mDevice);
 }
 


### PR DESCRIPTION
	W Watchdog: *** WATCHDOG KILLING SYSTEM PROCESS: Blocked in handler on main thread (main)
	W Watchdog: main thread stack trace:
	W Watchdog:     at android.os.HwRemoteBinder.transact(Native Method)
	W Watchdog:     at android.hardware.biometrics.fingerprint.V2_1.IBiometricsFingerprint$Proxy.authenticate(IBiometricsFi
	W Watchdog:     at com.android.server.fingerprint.AuthenticationClient.start(AuthenticationClient.java:121)
	W Watchdog:     at com.android.server.fingerprint.FingerprintService.startClient(FingerprintService.java:573)
	W Watchdog:     at com.android.server.fingerprint.FingerprintService.startAuthentication(FingerprintService.java:861)
	W Watchdog:     at com.android.server.fingerprint.FingerprintService.-wrap7(Unknown Source:0)
	W Watchdog:     at com.android.server.fingerprint.FingerprintService$FingerprintServiceWrapper$3.run(FingerprintService
	W Watchdog:     at android.os.Handler.handleCallback(Handler.java:789)
	W Watchdog:     at android.os.Handler.dispatchMessage(Handler.java:98)
	W Watchdog:     at android.os.Looper.loop(Looper.java:164)
	W Watchdog:     at com.android.server.SystemServer.run(SystemServer.java:437)
	W Watchdog:     at com.android.server.SystemServer.main(SystemServer.java:263)
	W Watchdog:     at java.lang.reflect.Method.invoke(Native Method)
	W Watchdog:     at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
	W Watchdog:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
	W Watchdog: *** GOODBYE!